### PR TITLE
Add release workflow, Dockerfile, and standardize test deps (RFJ-065)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.idea
+.claude
+*.md
+!README.md
+docs/
+scripts/
+META-INF/
+**/src/
+**/target/surefire-reports/
+**/target/jacoco.exec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build JAR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set Maven version
+        run: mvn -B versions:set -DnewVersion=${{ steps.version.outputs.VERSION }} -DgenerateBackupPoms=false
+
+      - name: Build and test
+        run: mvn -B verify
+
+      - name: Upload JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: refinej-jar
+          path: refinej-cli/target/refinej-cli-*.jar
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: refinej-jar
+          path: dist/
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Rename JAR
+        run: cp dist/refinej-cli-*.jar dist/refinej-cli-${{ steps.version.outputs.VERSION }}.jar
+
+      - name: Generate checksums
+        working-directory: dist
+        run: sha256sum refinej-cli-${{ steps.version.outputs.VERSION }}.jar > SHA256SUMS.txt
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "RefineJ ${{ steps.version.outputs.VERSION }}" \
+            --generate-notes \
+            dist/refinej-cli-${{ steps.version.outputs.VERSION }}.jar \
+            dist/SHA256SUMS.txt
+
+  docker:
+    name: Build & Push Docker Image
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: refinej-jar
+          path: refinej-cli/target/
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM eclipse-temurin:21-jre-alpine
+
+LABEL org.opencontainers.image.title="RefineJ" \
+      org.opencontainers.image.description="Java refactoring CLI powered by static analysis" \
+      org.opencontainers.image.source="https://github.com/alexmond/refinej" \
+      org.opencontainers.image.licenses="MIT"
+
+RUN addgroup -S refinej && adduser -S refinej -G refinej
+
+COPY refinej-cli/target/refinej-cli-*.jar /app/refinej.jar
+
+USER refinej
+WORKDIR /workspace
+
+ENTRYPOINT ["java", "-jar", "/app/refinej.jar"]

--- a/docs/ENGINE-COMPARISON.adoc
+++ b/docs/ENGINE-COMPARISON.adoc
@@ -1,0 +1,225 @@
+= Engine Comparison: Spoon vs OpenRewrite vs JavaParser
+:toc:
+
+== Overview
+
+RefineJ supports three Java refactoring engines behind the `RefactoringEngine` interface.
+This document compares them by complexity, functionality, and suitability as the single
+production engine.
+
+== Implementation Status
+
+[cols="1,1,1,1"]
+|===
+| Feature | SpoonEngine | OpenRewriteEngine | JavaParserEngine
+
+| indexProject       | ✅ Full  | ✅ Full  | ❌ Stub
+| findSymbol         | ✅ Full  | ✅ Full  | ❌ Stub
+| getAllSymbols       | ✅ Full  | ✅ Full  | ❌ Stub
+| findReferences     | ✅ Full  | ✅ Full  | ❌ Stub
+| computeRename      | ✅ Full  | ✅ Full  | ❌ Stub
+| computeMove        | ✅ Full  | ✅ Full  | ❌ Stub
+| apply              | ✅ Full  | ✅ Full  | ❌ Stub
+|===
+
+== Complexity Comparison
+
+=== SpoonEngine (~800 lines total)
+
+[cols="1,1"]
+|===
+| Component | Lines
+
+| SpoonEngine.java          | ~180
+| SymbolExtractor.java      | ~180
+| ReferenceExtractor.java   | ~200
+| SpoonRenameComputer.java  | ~130
+| SpoonMoveComputer.java    | ~120
+|===
+
+*Complexity*: Medium. Spoon provides a rich, well-documented AST (`CtModel`) with
+excellent position tracking (`getPosition().getLine()`). The `CtScanner` visitor pattern
+is clean and predictable.
+
+=== OpenRewriteEngine (~900 lines total)
+
+[cols="1,1"]
+|===
+| Component | Lines
+
+| OpenRewriteEngine.java         | ~190
+| RewriteSymbolExtractor.java    | ~200
+| RewriteReferenceExtractor.java | ~230
+| RewriteRenameComputer.java     | ~130
+| RewriteMoveComputer.java       | ~120
+|===
+
+*Complexity*: Medium-High. OpenRewrite's Lossless Semantic Tree (LST) is powerful for
+large-scale migrations, but its API is less intuitive for our use case. Position tracking
+requires manual source-text search since line numbers aren't directly accessible from the
+LST nodes. The `JavaIsoVisitor` pattern works but has quirks (e.g., annotation types
+return `NameTree` not `TypeTree`).
+
+=== JavaParserEngine (stub only)
+
+Not yet implemented. JavaParser 3.x is the lightest library (~2 MB JAR) with good
+docs, but its symbol solver requires explicit classpath configuration and can be fragile.
+
+== Functional Comparison
+
+=== Symbol Extraction Quality
+
+[cols="1,1,1"]
+|===
+| Aspect | Spoon | OpenRewrite
+
+| Position accuracy
+| Exact (native API)
+| Approximate (text search)
+
+| Method FQN format
+| `Class#method(param1,param2)` — reliable
+| `Class#method(param1,param2)` — relies on `JavaType.Method`
+
+| Field detection
+| Robust (`CtField` visitor)
+| Manual iteration of class body statements
+
+| Package symbols
+| `visitPackage()` callback
+| `visitPackage()` callback
+|===
+
+=== Reference Extraction Quality
+
+Both engines extract the same 8 `UsageKind` types:
+IMPORT, EXTENDS, IMPLEMENTS, NEW_INSTANCE, METHOD_CALL, FIELD_ACCESS, TYPE_REFERENCE, ANNOTATION.
+
+[cols="1,1,1"]
+|===
+| Aspect | Spoon | OpenRewrite
+
+| Line number accuracy
+| Exact
+| Approximate (±1 line possible)
+
+| Deduplication
+| Set-based key
+| Set-based key (identical approach)
+
+| Cross-package refs
+| Reliable
+| Reliable
+|===
+
+=== Rename/Move Quality
+
+Both engines use **identical** text-based rename/move computers. The computers operate on
+the indexed symbol/reference maps, not on engine-specific ASTs. This means rename and move
+quality is identical between engines — the difference is only in indexing quality.
+
+NOTE: This is a code duplication smell. `SpoonRenameComputer` and `RewriteRenameComputer`
+(and their Move counterparts) are nearly identical. They should be extracted to
+`refinej-core` as shared utilities.
+
+== Performance
+
+From the integration test performance sanity checks:
+
+[cols="1,1,1"]
+|===
+| Operation | Spoon | OpenRewrite
+
+| Index complex fixture (7 files)
+| ~1-2s
+| ~2-3s
+
+| Rename (User → Account)
+| <100ms
+| <100ms
+|===
+
+OpenRewrite's parser startup is heavier because it loads the full rewrite infrastructure.
+For a CLI tool processing single projects, this difference is negligible.
+
+== Dependency Footprint
+
+[cols="1,1,1"]
+|===
+| Aspect | Spoon | OpenRewrite
+
+| Core JAR
+| ~6 MB (spoon-core)
+| ~4 MB (rewrite-java) + ~8 MB (rewrite-java-17)
+
+| Transitive deps
+| Eclipse JDT compiler
+| Jackson, Micrometer, multiple rewrite modules
+
+| Total footprint
+| ~15 MB
+| ~25 MB
+|===
+
+== Recommendation
+
+=== Keep: SpoonEngine (Primary)
+
+**Reasons:**
+
+1. **Better position tracking** — native `getPosition().getLine()` vs source-text search.
+   This becomes critical for accurate rename/move in larger codebases.
+2. **Smaller dependency footprint** — ~15 MB vs ~25 MB, matters for CLI distribution.
+3. **Simpler API** — `CtScanner` with typed `visitCtClass`, `visitCtMethod`, etc. is more
+   intuitive than OpenRewrite's `JavaIsoVisitor` with manual type checking.
+4. **Battle-tested for this use case** — Spoon was specifically designed for source code
+   analysis and transformation, which is exactly what RefineJ does.
+
+=== Consider Dropping: OpenRewriteEngine
+
+**Reasons to drop:**
+
+- Adds ~10 MB to the distribution with no functional advantage
+- Position tracking workaround is fragile
+- Rename/move computers are duplicated (text-based, engine-agnostic)
+- OpenRewrite's strength (large-scale migrations across many repos) doesn't align
+  with RefineJ's use case (single-project refactoring)
+
+**Reasons to keep (if desired):**
+
+- OpenRewrite has a huge recipe ecosystem for automated migrations
+- Some users may prefer OpenRewrite's LST for custom recipes
+- Cross-engine validation catches bugs in either implementation
+
+=== Alternative: JavaParserEngine
+
+If a second engine is desired for validation/comparison, **JavaParser** would be a
+better complement to Spoon than OpenRewrite:
+
+- Much lighter (~2 MB)
+- Different parsing approach (hand-written parser vs Eclipse JDT)
+- Good position tracking
+- Active community
+
+== Migration Path
+
+If consolidating to Spoon only:
+
+1. Extract rename/move computers to `refinej-core` as shared utilities
+2. Remove `refinej-engine-rewrite` module from the build
+3. Remove `refinej-engine-javaparser` module (or implement it as the second engine)
+4. Simplify `EngineConfig` to only load SpoonEngine
+5. Remove `--engine` CLI flag (or keep it for future extensibility)
+6. Update README, CLAUDE.md, and docs
+
+== Decision Log
+
+_Record engine consolidation decisions here as they are made._
+
+|===
+| Date | Decision | Rationale
+
+| (pending)
+| (awaiting user decision)
+| See recommendation above
+|===

--- a/refinej-engine-rewrite/pom.xml
+++ b/refinej-engine-rewrite/pom.xml
@@ -40,15 +40,10 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Test dependencies -->
+        <!-- Test -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/refinej-engine-spoon/pom.xml
+++ b/refinej-engine-spoon/pom.xml
@@ -36,13 +36,8 @@
 
         <!-- Test -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- Adds `release.yml` workflow: triggered on `v*` tags, builds JAR, creates GitHub Release with SHA256 checksums, builds and pushes Docker image to `ghcr.io/alexmond/refinej`
- Adds `Dockerfile` (eclipse-temurin:21-jre-alpine) with non-root user and `.dockerignore`
- Replaces direct `junit-jupiter`/`assertj-core` with `spring-boot-starter-test` in engine-spoon and engine-rewrite modules
- Adds `docs/ENGINE-COMPARISON.adoc` — full comparison of Spoon vs OpenRewrite vs JavaParser

## Test plan
- [x] All 70 tests pass locally (`mvnw verify`)
- [ ] CI passes on this PR
- [ ] After merge, tag `v0.1.0` to trigger release workflow

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)