### PR TITLE
ci: builder pipeline analogs

### DIFF
--- a/.builder/pipelines/build.yml
+++ b/.builder/pipelines/build.yml
@@ -1,0 +1,23 @@
+name: Build & Test
+
+on: [push, manual]
+push:
+  branches: [main]
+
+jobs:
+  build:
+    image: eclipse-temurin:21-jdk
+    matrix:
+      java: ["21"]
+    cache:
+      key: m2-refinej
+      paths: [.m2/repository]
+    steps:
+      - name: Checkout
+        run: git clone --depth 1 https://github.com/alexmond/refinej.git .
+      - name: Build (skip tests)
+        run: ./mvnw -B clean install -DskipTests -Dmaven.repo.local=.m2/repository
+      - name: Run tests
+        run: ./mvnw -B verify -Dmaven.repo.local=.m2/repository
+    artifacts:
+      - "**/target/surefire-reports/"

--- a/.builder/pipelines/release.yml
+++ b/.builder/pipelines/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on: [tag, manual]
+
+inputs:
+  VERSION:
+    type: string
+    description: "Release version (without the leading v), e.g. 1.2.3"
+    required: true
+
+jobs:
+  build:
+    image: eclipse-temurin:21-jdk
+    cache:
+      key: m2-refinej
+      paths: [.m2/repository]
+    steps:
+      - name: Checkout
+        run: git clone --depth 1 https://github.com/alexmond/refinej.git .
+      - name: Set Maven version
+        run: ./mvnw -B versions:set -DnewVersion=$VERSION -DgenerateBackupPoms=false -Dmaven.repo.local=.m2/repository
+      - name: Build and test
+        run: ./mvnw -B verify -Dmaven.repo.local=.m2/repository
+    artifacts:
+      - "refinej-cli/target/refinej-cli-*.jar"
+
+  docker:
+    image: docker:27
+    needs: [build]
+    needs-artifacts: [build]
+    steps:
+      - name: Checkout
+        run: git clone --depth 1 https://github.com/alexmond/refinej.git .
+      - name: Build Docker image
+        run: docker build -t refinej:$VERSION .


### PR DESCRIPTION
Adds `.builder/pipelines/` analogs of the two GitHub Actions workflows, so the project can also build under builder (the GitLab-style, AI-aware CI/CD platform).

- `build.yml` — push to `main` + manual; Java 21 matrix on `eclipse-temurin:21-jdk` with an `.m2` cache, runs `./mvnw clean install -DskipTests` then `./mvnw verify`, publishes the surefire reports as artifacts.
- `release.yml` — tag + manual (takes a `VERSION` input); sets the Maven version, runs `./mvnw verify`, publishes the CLI jar, then a `docker build` of the image.

Additive and inert — the existing GitHub Actions workflows are untouched and builder is not wired to this repo.

Translation gaps (builder-side, noted not blocking):
- No `CI_COMMIT_TAG` on tag triggers, so the release version is passed as an explicit `VERSION` input rather than derived from the tag.
- GitHub Release creation (`gh release create`, checksums, generated notes) and the GHCR multi-tag push are dropped — builder has no Pages/release-publish or multi-tag docker-push step; the docker job builds the image only.