### PR TITLE
docs: evaluate compiler-grade engines (jdtls/JDT, javac) + Phase 7 PoC

### DIFF
--- a/docs/ENGINE-COMPARISON.adoc
+++ b/docs/ENGINE-COMPARISON.adoc
@@ -362,6 +362,133 @@ Cons: Tripled maintenance, 3x code duplication in rename/move computers.
 
 **Total: 152 tests pass across all modules.**
 
+== Candidate Fourth Engine: Compiler-Grade Backends
+
+The three current engines are all **in-process AST libraries** that RefineJ builds
+refactorings on top of. Two compiler-grade alternatives are worth evaluating because
+they solve — for free — the two hardest problems the current engines struggle with:
+full type/binding resolution, Lombok, and (critically) they are **not capped at Java 17**.
+
+Both are documented here as reference options for a future `JavacEngine` / `JdtEngine`
+PoC (see `ROADMAP.adoc`, Phase 7).
+
+=== Eclipse JDT (jdtls / JDT Core)
+
+**jdtls** (Eclipse JDT Language Server) is the LSP server that powers Java in VS Code,
+Neovim, etc. It is built on **Eclipse JDT Core** — the same industrial ECJ compiler and
+Java model (`ICompilationUnit`, `IType`, `IMethod`) used by the Eclipse IDE, and the same
+compiler Spoon already uses under the hood for parsing.
+
+==== Two integration surfaces
+
+[cols="1,3",options="header"]
+|===
+| Surface | Fit for RefineJ
+
+| **jdtls** (the LSP *server*)
+| Poor. It is a separate OSGi/Equinox process spoken to over LSP (JSON-RPC). A `JdtlsEngine`
+  would need an LSP client (LSP4J), process lifecycle management, and async→sync adaptation.
+  Heavy (~100+ MB server bundle + its own JDK), slow cold start (full workspace import/build),
+  and stateful — all of which fight RefineJ's one-shot CLI model.
+
+| **JDT Core** (the *library*)
+| Good. Embed `org.eclipse.jdt:org.eclipse.jdt.core` in-process (like Spoon/JavaParser). The
+  LTK refactoring framework (`org.eclipse.ltk`, `org.eclipse.jdt.core.manipulation`) produces
+  text edits directly, mapping cleanly to `ChangeSet`. Fiddly `IJavaProject` bootstrap outside
+  an Eclipse runtime, but no process boundary.
+|===
+
+==== Strengths vs. current engines
+
+- **Best-in-class type resolution** — full ECJ compiler bindings.
+- **Best real-world Lombok** — `-javaagent:lombok.jar`, the mechanism the actual compiler uses.
+- **Current Java** — JDT tracks 21/23/25; the current three are all capped at 17.
+- **Built-in refactoring** — rename/move/extract already exist and are battle-tested (unlike
+  Spoon/JP, where RefineJ hand-builds them). `WorkspaceEdit` → `ChangeSet` is ~1:1.
+
+==== Weaknesses
+
+- **Heaviest footprint** of any option (jdtls ~100+ MB; JDT Core still large).
+- **Wrong integration shape** for jdtls-the-server (process, async, stateful).
+- JDT Core outside Eclipse needs careful classpath/`IJavaProject` bootstrapping.
+
+**Takeaway**: if the goal is Eclipse-quality refactoring, use **JDT Core as a library**, not
+jdtls-the-server. jdtls only earns its cost if editor-grade LSP interop is itself a goal.
+
+=== javac Compiler Tree API (+ Kythe reference)
+
+The JDK's own compiler front-end: `javax.tools.JavaCompiler` plus the Compiler Tree API
+(`com.sun.source.tree`, `com.sun.source.util` — `Trees`, `TreePathScanner`, `Elements`,
+`Types`). Embeddable **in-process as a library**, exactly like Spoon and JavaParser. The
+well-known LSP built on it is `georgewfraser/java-language-server` (the lightweight
+alternative to jdtls — often mis-attributed to Google).
+
+==== Sketch of a `JavacEngine`
+
+`ToolProvider.getSystemJavaCompiler()` → `JavacTask` → `CompilationUnitTree`s → walk with a
+`TreePathScanner`, resolve each node via `Trees.getElement(path)` → map to `Symbol`/`Reference`.
+Positions come from `SourcePositions` / `LineMap` (exact). Fits the `RefactoringEngine`
+contract directly.
+
+==== Strengths — it dominates JavaParser
+
+[cols="1,2",options="header"]
+|===
+| Dimension | javac
+
+| Footprint        | **~0 MB — it ships in the JDK** (`jdk.compiler` module), lighter than JavaParser's ~5 MB
+| Java version     | **Tracks the running JDK** (21/25 native) — the only option not capped at Java 17
+| Type resolution  | Full — it *is* the compiler (`Element` / `TypeMirror`), on par with Spoon/JDT
+| Lombok           | Strong — javac is Lombok's native habitat (annotation processor on the AP classpath)
+| Process model    | In-process library — same shape as Spoon/JavaParser
+|===
+
+Net: same lightweight in-process feel as JavaParser, but with **real compiler bindings** and
+**current Java** instead of a partial symbol solver capped at 17.
+
+==== Weaknesses
+
+- **No built-in refactoring** — analysis-only; rename/move must be hand-built (same as today
+  for Spoon/JP). A great *index/resolve* backend, not a *transform* one.
+- **API discipline required** — stay on the public `com.sun.source.*` API. Reaching into
+  `com.sun.tools.javac.*` internals needs `--add-exports` and is fragile across JDK releases.
+- **Not lossless** — comments/formatting dropped, but RefineJ applies edits via text+positions,
+  so this doesn't bite.
+
+==== Kythe (Google's actual tool — reference only)
+
+Google's open-source semantic indexing infrastructure: a language-agnostic node/edge graph
+(defines/ref/childof) that powers Google-scale code search; its Java indexer is itself a javac
+plugin. Philosophically identical to RefineJ's symbol+reference index, but it is an **offline
+pipeline** (extract → index → serve), not an embeddable library or LSP server. Wrong shape to
+integrate — but a useful **reference model for the index graph schema**.
+
+=== Summary Ranking (as fourth-engine candidates)
+
+[cols="1,3",options="header"]
+|===
+| Candidate | Assessment
+
+| **javac Compiler Tree API**
+| **Strongest fit.** Lightest footprint, only option on current Java, real resolution,
+  in-process. Natural upgrade path from JavaParser. No built-in transforms (hand-build, as today).
+
+| **JDT Core (library)**
+| Strong for *refactoring quality* (built-in rename/move, best Lombok), at a heavy footprint and
+  a fiddly bootstrap. The "high-fidelity" option.
+
+| **jdtls (LSP server)**
+| Poor architectural fit — process boundary, async, ~100+ MB, slow cold start. Only if LSP
+  interop is itself a goal.
+
+| **Kythe**
+| Not an engine — a reference model for the index schema.
+|===
+
+**Recommendation for the PoC**: spike **`JavacEngine`** first (best fit, lightest, breaks the
+Java-17 ceiling); keep **JDT Core** as the fallback if compiler-grade *built-in* refactoring is
+wanted later.
+
 == Decision Log
 
 |===

--- a/docs/ROADMAP.adoc
+++ b/docs/ROADMAP.adoc
@@ -146,6 +146,34 @@ End-to-end rename of a class in Petclinic succeeds with preview/apply and git di
 **Phase Exit Criteria**:
 v0.1.0 released, fully documented, and AI-agent friendly.
 
+== Phase 7: Compiler-Grade Engine PoC (Post-MVP | 6 person-days)
+
+Evaluate a fourth `RefactoringEngine` backed by a real Java compiler, to break the
+**Java-17 ceiling** shared by all three current engines (Spoon 10.4, JavaParser 3.25,
+OpenRewrite rewrite-java-17) and to get full type/binding resolution + first-class Lombok.
+
+Two reference backends are analysed in `docs/ENGINE-COMPARISON.adoc`
+("Candidate Fourth Engine: Compiler-Grade Backends"):
+
+* **javac Compiler Tree API** (`com.sun.source.*`) — in-process, ~0 MB (ships in the JDK),
+  tracks the running JDK version, real compiler bindings. **Recommended PoC target.**
+* **Eclipse JDT Core** (library, not the jdtls server) — built-in LTK rename/move and best
+  Lombok, at a heavier footprint. Fallback / "high-fidelity" option.
+
+[cols="1,4,1,1,2,1",options="header"]
+|===
+| ID      | Title                                      | Priority | Effort | Dependencies | Status
+| RFJ-070 | Spike `JavacEngine` in a new `refinej-engine-javac` module: `JavacTask` → `TreePathScanner` → `Symbol`/`Reference` mapping via `Trees.getElement`; public `com.sun.source.*` API only (no `--add-exports`) | P3 | 3d | Phase 4 | TODO
+| RFJ-071 | Wire `JavacEngine` into `EngineType`, `EngineConfig`, `EngineResolver`, `--engine javac`; pass `EngineContractTest` | P3 | 1d | RFJ-070 | TODO
+| RFJ-072 | Validate on a Java 21+ fixture (records, sealed, pattern switch) that current engines cannot index; confirm Lombok via annotation-processing classpath | P3 | 1d | RFJ-070 | TODO
+| RFJ-073 | Update `ENGINE-COMPARISON.adoc` with measured javac footprint/perf/resolution vs. the three engines; decide javac vs. JDT Core for a production fourth engine | P3 | 1d | RFJ-072 | TODO
+|===
+
+**Phase Exit Criteria**:
+`refinej --engine javac index <java21-fixture>` indexes source the other three engines cannot
+(capped at Java 17), passes the shared `EngineContractTest`, and the comparison doc records a
+go/no-go decision on promoting a compiler-grade engine.
+
 == How to Turn This Roadmap into Tickets
 
 1. Copy each row and create a GitHub issue with the exact **Title**.


### PR DESCRIPTION
## What

Analyses two compiler-grade backends as a potential **fourth `RefactoringEngine`**, and adds a roadmap phase + tickets to spike one.

### `docs/ENGINE-COMPARISON.adoc` — new "Candidate Fourth Engine" section
- **Eclipse JDT** — separates jdtls-the-LSP-server (poor architectural fit: process boundary, ~100+ MB, slow cold start) from **JDT Core-the-library** (good fit: in-process, built-in LTK rename/move, best Lombok).
- **javac Compiler Tree API** — in-process, ~0 MB (ships in the JDK), tracks the running JDK version, real compiler bindings; a table showing it dominates JavaParser. **Kythe** covered as a reference-only index-graph model.
- Summary ranking + PoC recommendation: **spike `JavacEngine` first**, keep JDT Core as fallback.

### `docs/ROADMAP.adoc` — new Phase 7 (post-MVP, P3)
- RFJ-070..073: spike `JavacEngine` in a new `refinej-engine-javac` module, wire `--engine javac`, validate on a Java 21 fixture + Lombok, record a go/no-go.
- Motivation: break the **Java-17 ceiling** shared by Spoon 10.4 / JavaParser 3.25 / rewrite-java-17.

## Why

All three current engines are capped at Java 17 and hand-build resolution/Lombok handling. A javac-based engine is the lightest option, tracks current Java, and gives full compiler bindings.

## Tickets

Tracked as #60 (spike), #61 (wiring), #62 (Java 21 + Lombok validation), #63 (go/no-go), under the new **Phase 7 – Compiler-Grade Engine PoC** milestone.

Docs-only change; no code or build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)