### PR TITLE
chore: gitignore local Claude Code settings & prompt-coach state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,10 @@ target/
 # RefineJ runtime index & backups
 .refinej/
 
-# Claude Code local settings (machine-specific)
+# Claude Code local settings & runtime state (machine-specific)
 .claude/settings.local.json
+.claude/settings.json
+.claude/prompt-coach/
 
 # Build artifacts
 META-INF/


### PR DESCRIPTION
Ignore two machine-specific `.claude` local files so they stay out of version control:

- `.claude/settings.json` — enabled-plugins config (local tooling choice, not shared)
- `.claude/prompt-coach/` — prompt-coach runtime state (log + state.json)

gitignore-only change; no code, build, or CI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)